### PR TITLE
api success schemas

### DIFF
--- a/lib/apidocToSwagger.js
+++ b/lib/apidocToSwagger.js
@@ -14,7 +14,11 @@ function toSwagger(apidocJson, projectJson) {
   return swagger;
 }
 
-
+/**
+ * add project info loaded from package.json
+ * @param projectJson
+ * @returns {{}}
+ */
 function addInfo(projectJson) {
   var info = {};
   info["title"] = projectJson.title;
@@ -37,8 +41,29 @@ function extractPaths(apidocJson) {
   return paths;
 }
 
+
 /**
- * Extracts parameters from method and creates schema definition
+ * In order to work with schemas in swagger we need to extract schema definitions for post patch and put requests
+ * Creating definitions object
+ * @param apidocJson
+ * @returns {{}}
+ */
+function extractDefinitions(apidocJson) {
+  var definitions = {};
+  for (var i = 0; i < apidocJson.length; i++) {
+    if (apidocJson[i].parameter) {
+      definitions[apidocJson[i].name] = createSchemaDefinition(apidocJson[i].parameter.fields);
+    }
+    if (apidocJson[i].success) {
+      definitions[apidocJson[i].name + "Success"] = createSchemaDefinition(apidocJson[i].success.fields);
+    }
+
+  }
+  return definitions;
+}
+
+/**
+ * Extracts parameters from method and creates schema definitions block
  * @param method
  * @returns {{properties: {}, required: Array}}
  */
@@ -47,7 +72,7 @@ function createSchemaDefinition(fields) {
   var required = [];
   //create input schema definitions
   for (var type in fields) {
-    if (type != "path" && type!="query") {
+    if (type != "path" && type != "query") {
       for (var i = 0; i < fields[type].length; i++) {
         pathItemObject[fields[type][i].field] =
         {
@@ -64,26 +89,6 @@ function createSchemaDefinition(fields) {
   return {properties: pathItemObject, required: required};
 }
 
-
-/**
- * In order to work with schemas in swagger we need to extract schema definitions for post patch and put requests
- * Creating definitions object
- * @param apidocJson
- * @returns {{}}
- */
-function extractDefinitions(apidocJson) {
-  var definitions = {};
-  for (var i = 0; i < apidocJson.length; i++) {
-    if (apidocJson[i].parameter) {
-      definitions[apidocJson[i].name] = createSchemaDefinition(apidocJson[i].parameter.fields);
-    }
-    if (apidocJson[i].success) {
-      definitions[apidocJson[i].name+"Success"] = createSchemaDefinition(apidocJson[i].success.fields);
-    }
-
-  }
-  return definitions;
-}
 
 /**
  * Generate method output
@@ -155,18 +160,18 @@ function extractMethodResponses(method) {
   var res = {};
   //extract success
   if (method.success && method.success.fields) {
-    key = Object.keys(method.success.fields)[0];
-      res[key] = {
-        "description": "successful operation",
-        "schema": {"$ref": "#/definitions/"+method.name+"Success"}
-      };
-    }
+    var key = Object.keys(method.success.fields)[0];
+    res[key] = {
+      "description": "successful operation",
+      "schema": {"$ref": "#/definitions/" + method.name + "Success"}
+    };
+  }
 
   //extract errors
   if (method.error && method.error.fields) {
     key = Object.keys(method.error.fields)[0];
     for (err in method.error.fields[key]) {
-      res[method.error.fields[key][err].field] = {"description":method.error.fields[key][err].description};
+      res[method.error.fields[key][err].field] = {"description": method.error.fields[key][err].description};
     }
   }
   return res;

--- a/lib/apidocToSwagger.js
+++ b/lib/apidocToSwagger.js
@@ -135,7 +135,7 @@ function extractParameters(method) {
         for (var i = 0; i < method.parameter.fields[type].length; i++) {
           pathItemObject.push({
             name: method.parameter.fields[type][i].field,
-            in: method.parameter.fields[type][i].group.toLowerCase(),
+            in: type === 'file' ? 'formData' : method.parameter.fields[type][i].group.toLowerCase(),
             required: !method.parameter.fields[type][i].optional,
             type: method.parameter.fields[type][i].type.toLowerCase(),
             description: method.parameter.fields[type][i].description

--- a/lib/apidocToSwagger.js
+++ b/lib/apidocToSwagger.js
@@ -74,8 +74,13 @@ function createSchemaDefinition(fields) {
 function extractDefinitions(apidocJson) {
   var definitions = {};
   for (var i = 0; i < apidocJson.length; i++) {
-    definitions[apidocJson[i].name] = createSchemaDefinition(apidocJson[i].parameter.fields);
-    definitions[apidocJson[i].name+"Success"] = createSchemaDefinition(apidocJson[i].success.fields);
+    if (apidocJson[i].parameter) {
+      definitions[apidocJson[i].name] = createSchemaDefinition(apidocJson[i].parameter.fields);
+    }
+    if (apidocJson[i].success) {
+      definitions[apidocJson[i].name+"Success"] = createSchemaDefinition(apidocJson[i].success.fields);
+    }
+
   }
   return definitions;
 }

--- a/lib/apidocToSwagger.js
+++ b/lib/apidocToSwagger.js
@@ -1,47 +1,69 @@
 var _ = require('lodash');
 
 var swagger = {
-	swagger	: "2.0",
-	info	: {},
-	paths	: {},
-	definitions: {}
+  swagger: "2.0",
+  info: {},
+  paths: {},
+  definitions: {}
 };
 
 function toSwagger(apidocJson, projectJson) {
-	swagger.info = addInfo(projectJson);
-	swagger.paths = extractPaths(apidocJson);
-	swagger.definitions = extractDefinitions(apidocJson);
-	return swagger;
+  swagger.info = addInfo(projectJson);
+  swagger.paths = extractPaths(apidocJson);
+  swagger.definitions = extractDefinitions(apidocJson);
+  return swagger;
 }
 
 
 function addInfo(projectJson) {
-	var info = {};
-	info["title"] = projectJson.title;
-	info["version"] = projectJson.version;
-	info["description"] = projectJson.description;
-	return info;
+  var info = {};
+  info["title"] = projectJson.title;
+  info["version"] = projectJson.version;
+  info["description"] = projectJson.description;
+  return info;
 }
 
 /**
  * Extracts paths provided in json format
- * post, patch, put request parameters are extracted in body
- * get and delete are extracted to path parameters
  * @param apidocJson
  * @returns {{}}
  */
-function extractPaths(apidocJson){
-	var apiPaths = groupByUrl(apidocJson);
-	var paths = {};
-	for (var i = 0; i < apiPaths.length; i++) {
-		if (apiPaths[i].verbs[0].type == 'post' || apiPaths[i].verbs.type == 'patch' || apiPaths[i].verbs.type == 'put') {
-			paths[apiPaths[i].verbs[0].url] = createPostPushPutOutput(apiPaths[i].verbs[0]);
-		} else {
-			paths[apiPaths[i].verbs[0].url] = createGetDeleteOutput(apiPaths[i].verbs[0]);
-		}
-	}
-	return paths;
+function extractPaths(apidocJson) {
+  var paths = {};
+  var apiPaths = groupByUrl(apidocJson);
+  for (var key in apiPaths) {
+    paths[key] = extractMethods(apiPaths[key]);
+  }
+  return paths;
 }
+
+/**
+ * Extracts parameters from method and creates schema definition
+ * @param method
+ * @returns {{properties: {}, required: Array}}
+ */
+function createSchemaDefinition(fields) {
+  var pathItemObject = {};
+  var required = [];
+  //create input schema definitions
+  for (var type in fields) {
+    if (type != "path" && type!="query") {
+      for (var i = 0; i < fields[type].length; i++) {
+        pathItemObject[fields[type][i].field] =
+        {
+          type: fields[type][i].type.toLowerCase(),
+          description: fields[type][i].description
+        }
+        //all required fields are pushed to required object
+        if (!fields[type][i].optional) {
+          required.push(fields[type][i].field);
+        }
+      }
+    }
+  }
+  return {properties: pathItemObject, required: required};
+}
+
 
 /**
  * In order to work with schemas in swagger we need to extract schema definitions for post patch and put requests
@@ -50,124 +72,113 @@ function extractPaths(apidocJson){
  * @returns {{}}
  */
 function extractDefinitions(apidocJson) {
-	var apiPaths = groupByUrl(apidocJson);
-	var definitions = {};
-	for (var i = 0; i < apiPaths.length; i++) {
-		if (apiPaths[i].verbs[0].type == 'post' || apiPaths[i].verbs.type == 'patch' || apiPaths[i].verbs.type == 'put') {
-			definitions[apiPaths[i].verbs[0].name] = createSchemaDefinition(apiPaths[i].verbs[0]);
-		}
-	}
-	return definitions;
+  var definitions = {};
+  for (var i = 0; i < apidocJson.length; i++) {
+    definitions[apidocJson[i].name] = createSchemaDefinition(apidocJson[i].parameter.fields);
+    definitions[apidocJson[i].name+"Success"] = createSchemaDefinition(apidocJson[i].success.fields);
+  }
+  return definitions;
 }
 
-
 /**
- * Extracts parameters from method and creates schema definition
- * @param verbs
- * @returns {{properties: {}, required: Array}}
- */
-function createSchemaDefinition(verbs) {
-	var pathItemObject = {};
-	var required = [];
-	//iterate through all params and create param blocks
-	for (var i = 0; i < verbs.parameter.fields.Parameter.length; i++) {
-		pathItemObject[verbs.parameter.fields.Parameter[i].field] =
-		{
-			type: verbs.parameter.fields.Parameter[i].type.toLowerCase(),
-			description: verbs.parameter.fields.Parameter[i].description
-		}
-		//all required fields are pushed to required object
-		if (!verbs.parameter.fields.Parameter[i].optional) {
-			required.push(verbs.parameter.fields.Parameter[i].field);
-		}
-	}
-	return {properties: pathItemObject, required: required};
-}
-
-
-/**
- * All body parameters are extracted in one field and schema is used as single parameter
+ * Generate method output
  * @param verbs
  * @returns {{}}
  */
-function createPostPushPutOutput(verbs) {
-	var pathItemObject = {};
-	pathItemObject[verbs.type] = {
-		tags: [verbs.group],
-		summary: verbs.description,
-		consumes: [
-			"application/json"
-		],
-		produces: [
-			"application/json"
-		],
-		parameters: [
-			{
-				"in": "body",
-				"name": "body",
-				"description": verbs.description,
-				"required": true,
-				"schema": {
-					"$ref": "#/definitions/"+verbs.name
-				}
-			}
-		]
-	}
-	return pathItemObject;
+function extractMethods(methods) {
+  var pathItemObject = {};
+  for (var i = 0; i < methods.length; i++) {
+    pathItemObject[methods[i].type] = {
+      tags: [methods[i].group],
+      summary: methods[i].description,
+      consumes: [
+        "application/json"
+      ],
+      produces: [
+        "application/json"
+      ],
+      parameters: extractParameters(methods[i]),
+      responses: extractMethodResponses(methods[i])
+    }
+  }
+  return pathItemObject;
 }
 
 /**
- * Generate get, delete method output
- * @param verbs
- * @returns {{}}
- */
-function createGetDeleteOutput(verbs) {
-	var pathItemObject = {};
-	pathItemObject[verbs.type] = {
-		tags: [verbs.group],
-		summary: verbs.description,
-		consumes: [
-			"application/json"
-		],
-		produces: [
-			"application/json"
-		],
-		parameters: createPathParameters(verbs)
-	}
-	return pathItemObject;
-}
-
-/**
- * Iterate through all method parameters and create array of parameter objects which are stored as path parameters
+ * Iterate through all methods parameters and create array of parameter objects
  * @param verbs
  * @returns {Array}
  */
-function createPathParameters(verbs) {
-	var pathItemObject = [];
-	if (verbs.parameter) {
-		for (var i = 0; i < verbs.parameter.fields.Parameter.length; i++) {
-			pathItemObject.push({
-				name: verbs.parameter.fields.Parameter[i].field,
-				in: "path",
-				required: !verbs.parameter.fields.Parameter[i].optional,
-				type: verbs.parameter.fields.Parameter[i].type.toLowerCase(),
-				description: verbs.parameter.fields.Parameter[i].description
-			});
-		}
-	}
-	return pathItemObject;
+function extractParameters(method) {
+  var pathItemObject = [];
+  if (method.parameter) {
+    for (var type in method.parameter.fields) {
+      //body params are packed together and schema is defined in definitions with method name
+      if (type == "body") {
+        pathItemObject.push({
+          name: type,
+          in: type,
+          required: true,
+          type: type.toLowerCase(),
+          description: method.description,
+          "schema": {
+            "$ref": "#/definitions/" + method.name
+          }
+        });
+      } else {
+        //path params are created separately
+        for (var i = 0; i < method.parameter.fields[type].length; i++) {
+          pathItemObject.push({
+            name: method.parameter.fields[type][i].field,
+            in: method.parameter.fields[type][i].group.toLowerCase(),
+            required: !method.parameter.fields[type][i].optional,
+            type: method.parameter.fields[type][i].type.toLowerCase(),
+            description: method.parameter.fields[type][i].description
+          });
+        }
+      }
+    }
+  }
+  return pathItemObject;
 }
 
+/**
+ * extract method response codes
+ * @param method
+ */
+function extractMethodResponses(method) {
+  var res = {};
+  //extract success
+  if (method.success && method.success.fields) {
+    key = Object.keys(method.success.fields)[0];
+      res[key] = {
+        "description": "successful operation",
+        "schema": {"$ref": "#/definitions/"+method.name+"Success"}
+      };
+    }
+
+  //extract errors
+  if (method.error && method.error.fields) {
+    key = Object.keys(method.error.fields)[0];
+    for (err in method.error.fields[key]) {
+      res[method.error.fields[key][err].field] = {"description":method.error.fields[key][err].description};
+    }
+  }
+  return res;
+}
+
+/**
+ * In order to generate swagger for all methods they must be grouped by URL, and type(get, put, delete) is subobject
+ * See swagger specs for details.
+ * @param apidocJson
+ * @returns {*}
+ */
 function groupByUrl(apidocJson) {
-	return _.chain(apidocJson)
-		.groupBy("url")
-		.pairs()
-		.map(function (element) {
-			return _.object(_.zip(["url", "verbs"], element));
-		})
-		.value();
+  return _.groupBy(apidocJson, function (b) {
+    return b.url;
+  });
 }
 
 module.exports = {
-	toSwagger: toSwagger
+  toSwagger: toSwagger
 };


### PR DESCRIPTION
Hi,
i have done more changes in this pull request
- api success blocks are generated as success responses,
- there was an issue with same URL and different method for example GET /user, POST /user they were merged as one method instead of two.
- also added option to parse path and body params with
- @apiParam (body) {Number} id Users unique ID.
- @apiParam (path) {Number} id Users unique ID.

Check this and let me know what do you think.
Thanks,
Vladimir
