### PR TITLE
Fix #14 - makes access to Parameters attribute in fields non-breaking in cases where it is missing

### DIFF
--- a/lib/apidocToSwagger.js
+++ b/lib/apidocToSwagger.js
@@ -80,7 +80,8 @@ function createPostPushPutOutput(verbs, definitions, pathKeys) {
 	});
 
 	params = params.concat(pathParams);
-	var required = verbs.parameter && verbs.parameter.fields && verbs.parameter.fields.Parameter.length > 0;
+	var required = verbs.parameter && verbs.parameter.fields && 
+					verbs.parameter.fields.Parameter && verbs.parameter.fields.Parameter.length > 0;
 
 	params.push({
 			"in": "body",
@@ -270,7 +271,7 @@ function createPathParameters(verbs, pathKeys) {
 	pathKeys = pathKeys || [];
 
 	var pathItemObject = [];
-	if (verbs.parameter) {
+	if (verbs.parameter && verbs.parameter.fields.Parameter) {
 
 		for (var i = 0; i < verbs.parameter.fields.Parameter.length; i++) {
 			var param = verbs.parameter.fields.Parameter[i];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apidoc-swagger",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Convert api doc json to swagger json",
   "author": "Bahman Fakhr Sabahi",
   "license": {


### PR DESCRIPTION
This fixes issue #14 by ensuring that the Parameters array is not undefined before checking its length. 
