### PR TITLE
Use title as summary field if description is empty

### DIFF
--- a/lib/apidocToSwagger.js
+++ b/lib/apidocToSwagger.js
@@ -94,7 +94,7 @@ function createPostPushPutOutput(verbs, definitions, pathKeys) {
 	
 	pathItemObject[verbs.type] = {
 		tags: [verbs.group],
-		summary: removeTags(verbs.description),
+		summary: removeTags(verbs.description) || verbs.title,
 		consumes: [
 			"application/json"
 		],
@@ -236,7 +236,7 @@ function createGetDeleteOutput(verbs,definitions) {
 	var verbDefinitionResult = createVerbDefinitions(verbs,definitions);
 	pathItemObject[verbs.type] = {
 		tags: [verbs.group],
-		summary: removeTags(verbs.description),
+		summary: removeTags(verbs.description) || verbs.title,
 		consumes: [
 			"application/json"
 		],


### PR DESCRIPTION
Tiny hack to use title field is the description is empty (i.e. @apiDescription is not present).
