### PR TITLE
Add verbs.parameter.fields check

### DIFF
--- a/lib/apidocToSwagger.js
+++ b/lib/apidocToSwagger.js
@@ -270,7 +270,7 @@ function createPathParameters(verbs, pathKeys) {
 	pathKeys = pathKeys || [];
 
 	var pathItemObject = [];
-	if (verbs.parameter) {
+	if (verbs.parameter && verbs.parameter.fields) {
 
 		for (var i = 0; i < verbs.parameter.fields.Parameter.length; i++) {
 			var param = verbs.parameter.fields.Parameter[i];


### PR DESCRIPTION
There are cases where a verbs.parameter exists but verbs.parameter.fields does not exist. This improves the boolean check before executing verbs.parameter.fields.Parameter.length.