### PR TITLE
Fixes to work with swagger in node.js.  No null schema reference and remove required field if empty

### DIFF
--- a/lib/apidocToSwagger.js
+++ b/lib/apidocToSwagger.js
@@ -80,18 +80,28 @@ function createPostPushPutOutput(verbs, definitions, pathKeys) {
 	});
 
 	params = params.concat(pathParams);
-	var required = verbs.parameter && verbs.parameter.fields && 
-					verbs.parameter.fields.Parameter && verbs.parameter.fields.Parameter.length > 0;
+	var required = verbs.parameter && verbs.parameter.fields && verbs.parameter.fields.Parameter.length > 0;
 
-	params.push({
+
+	let alldata = {
 			"in": "body",
 			"name": "body",
 			"description": removeTags(verbs.description),
 			"required": required,
-			"schema": {
+	};
+	
+	if( verbDefinitionResult.topLevelParametersRef == null )
+	{
+		alldata['schema'] = {			
+		}
+	}
+	else	
+	{
+		alldata['schema'] = {
 				"$ref": "#/definitions/" + verbDefinitionResult.topLevelParametersRef
 			}
-		});
+	}
+	params.push(alldata);
 	
 	pathItemObject[verbs.type] = {
 		tags: [verbs.group],
@@ -102,7 +112,12 @@ function createPostPushPutOutput(verbs, definitions, pathKeys) {
 		produces: [
 			"application/json"
 		],
-		parameters: params
+		parameters: params,
+		responses: { "200" :
+			{
+				"description": "successful operation"
+			}
+		}
 	}
 
 	if (verbDefinitionResult.topLevelSuccessRef) {
@@ -178,7 +193,7 @@ function createFieldArrayDefinitions(fieldArray, definitions, topLevelRef, defau
 		};
 
 		definitions[objectName] = definitions[objectName] ||
-			{ properties : {}, required : [] };
+			{ properties : {} };
 
 		if (nestedName.propertyName) {
 			var prop = { type: (parameter.type || "").toLowerCase(), description: removeTags(parameter.description) };
@@ -197,6 +212,12 @@ function createFieldArrayDefinitions(fieldArray, definitions, topLevelRef, defau
 			definitions[objectName]['properties'][nestedName.propertyName] = prop;
 			if (!parameter.optional) {
 				var arr = definitions[objectName]['required'];
+				//  Make required only exist when there are required elements
+				if( arr == null )
+				{
+					definitions[objectName]['required'] = [];
+					arr = definitions[objectName]['required'];
+				}
 				if(arr.indexOf(nestedName.propertyName) === -1) {
 					arr.push(nestedName.propertyName);
 				}
@@ -271,7 +292,7 @@ function createPathParameters(verbs, pathKeys) {
 	pathKeys = pathKeys || [];
 
 	var pathItemObject = [];
-	if (verbs.parameter && verbs.parameter.fields.Parameter) {
+	if (verbs.parameter) {
 
 		for (var i = 0; i < verbs.parameter.fields.Parameter.length; i++) {
 			var param = verbs.parameter.fields.Parameter[i];


### PR DESCRIPTION
Ensure Require is only added when absolutely necessary
Make sure APIs with no parameters do not reference null $ref schemas