### PR TITLE
Required should not be created by default

### DIFF
--- a/lib/apidocToSwagger.js
+++ b/lib/apidocToSwagger.js
@@ -178,7 +178,7 @@ function createFieldArrayDefinitions(fieldArray, definitions, topLevelRef, defau
 		};
 
 		definitions[objectName] = definitions[objectName] ||
-			{ properties : {}, required : [] };
+			{ properties : {} };
 
 		if (nestedName.propertyName) {
 			var prop = { type: (parameter.type || "").toLowerCase(), description: removeTags(parameter.description) };
@@ -194,9 +194,12 @@ function createFieldArrayDefinitions(fieldArray, definitions, topLevelRef, defau
 				};
 			}
 
-			definitions[objectName]['properties'][nestedName.propertyName] = prop;
+			definitions[objectName].properties[nestedName.propertyName] = prop;
 			if (!parameter.optional) {
-				var arr = definitions[objectName]['required'];
+				if(definitions[objectName].required === undefined) {
+					definitions[objectName].required = []
+				}
+				var arr = definitions[objectName].required;
 				if(arr.indexOf(nestedName.propertyName) === -1) {
 					arr.push(nestedName.propertyName);
 				}


### PR DESCRIPTION
Swagger complains whenever you include required when its empty. Im now using this regex;
```
	cat doc/swagger.json | sed -e "s/,\"required\":[ ]*\[\]//g" | jq > doc/swagger-clean.json
```
I couldn't test this change (don't have a dev environment here), could anyone try it out?